### PR TITLE
Re-enable ITs and remove incorrectly env var setting for JVM memory allocation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Integration tests
-        run: make integration-all-github
+#        run: make integration-all-github
+        run: echo "Not running integration tests temporarily"
 
   get-publish-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Integration tests
-#        run: make integration-all-github
-        run: echo "Not running integration tests temporarily"
+        run: make integration-all-github
 
   get-publish-version:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ venv/
 *.crt
 *.pem
 *.p12
+
+*.jks

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,4 +62,4 @@ RUN chmod a+rw /var/log
 USER $USER_NAME
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["java", "${JAVA_MAX_MEM_ALLOCATION}", "-jar", "ucfs-claimant-kafka-consumer.jar"]
+CMD ["java", "-Xmx2g", "-jar", "ucfs-claimant-kafka-consumer.jar"]


### PR DESCRIPTION
This env var is not available at the time of container creation and is in fact given to the container at run time.
This is causing the container to build incorrectly.

The CMD will be overwritten in the task definition.