### PR TITLE
Add a filter processor.

### DIFF
--- a/containers/tests/features/steps/ucfs_consumer.py
+++ b/containers/tests/features/steps/ucfs_consumer.py
@@ -52,7 +52,7 @@ def step_impl(context, count, state, topic):
 
     for i in range(count):
 
-        db_object = topic_db_object(i, topic)
+        db_object = topic_db_object(i, topic, state != "nonino")
 
         if state == "mixed" and i % 2 == 1:
             db_object.pop("_id", None)
@@ -107,6 +107,7 @@ def step_impl(context, expected, record_type, table):
         count_cursor = connection.cursor()
         count_cursor.execute(f"SELECT count(*) FROM {table}")
         actual = count_cursor.fetchone()[0]
+
         assert expected == actual
         count_cursor.close()
 
@@ -232,19 +233,20 @@ def bootstrap_server():
     return "kafka:9092"
 
 
-def topic_db_object(i, topic):
+def topic_db_object(i, topic, include_nino: bool):
     if topic == "db.core.claimant":
-        return claimant_db_object(i)
+        return claimant_db_object(i, include_nino)
     return contract_db_object(i) if topic == "db.core.contract" else statement_db_object(i)
 
 
-def claimant_db_object(record_number: int):
-    return {
+def claimant_db_object(record_number: int, include_nino: bool):
+    wtf =  {
         "_id": {
             "citizenId": f"{record_number}"
         },
-        "nino": "AA123456A"
+        "nino": "AA123456A" if include_nino else ""
     }
+    return wtf
 
 
 def contract_db_object(record_number: int):

--- a/containers/tests/features/steps/ucfs_consumer.py
+++ b/containers/tests/features/steps/ucfs_consumer.py
@@ -240,13 +240,12 @@ def topic_db_object(i, topic, include_nino: bool):
 
 
 def claimant_db_object(record_number: int, include_nino: bool):
-    wtf =  {
+    return {
         "_id": {
             "citizenId": f"{record_number}"
         },
         "nino": "AA123456A" if include_nino else ""
     }
-    return wtf
 
 
 def contract_db_object(record_number: int):

--- a/containers/tests/features/ucfs_consumer.feature
+++ b/containers/tests/features/ucfs_consumer.feature
@@ -6,14 +6,15 @@ Feature: Consumes, decrypts, persists.
     Given 50 records exist on <table>
     And a data key has been acquired
     And 200 mixed messages have been posted to <topic>
-    Then <topic> offset will be committed at 200
+    And 100 nonino messages have been posted to db.core.claimant
+    Then <topic> offset will be committed at <topic_offset>
     And 100 updated records will be on <table>
     And the records on <table> can be deciphered
     And 100 messages will be sent to dead.letter.queue starting from offset <dlq_offset>
     Examples:
-      | topic             | dlq_offset | table     |
-      | db.core.claimant  |          0 | claimant  |
-      | db.core.statement |        100 | statement |
+      | topic             | dlq_offset | table     | topic_offset |
+      | db.core.claimant  |          0 | claimant  |         300  |
+      | db.core.statement |        100 | statement |         200  |
 
 
   Scenario Outline: Deletes are removed from the correct table

--- a/src/main/kotlin/ucfs/claimant/consumer/domain/Domain.kt
+++ b/src/main/kotlin/ucfs/claimant/consumer/domain/Domain.kt
@@ -39,6 +39,7 @@ data class CipherServiceEncryptionResult(val encryptingKeyId: String, val initia
 
 data class DecryptionResult(val extract: JsonProcessingExtract, val plainText: String)
 data class TransformationResult(val extract: JsonProcessingExtract, val transformedDbObject: String)
+data class FilterResult(val transformationResult: TransformationResult, val passThrough: Boolean)
 data class JsonProcessingExtract(val jsonObject: JsonObject, val id: String, val action: DatabaseAction,
                                  val timestampAndSource: Pair<String, String>)
 
@@ -51,11 +52,11 @@ typealias SourceRecord = ConsumerRecord<ByteArray, ByteArray>
 typealias SourceRecordProcessingResult = Pair<SourceRecord, String>
 typealias ValidationProcessingResult = Pair<SourceRecord, String>
 typealias JsonProcessingResult = Pair<SourceRecord, JsonProcessingExtract>
-typealias DeleteProcessingResult = Pair<SourceRecord, String>
 typealias ExtractionProcessingResult = Pair<SourceRecord, EncryptionExtractionResult>
 typealias DatakeyProcessingResult = Pair<SourceRecord, DataKeyResult>
 typealias DecryptionProcessingResult = Pair<SourceRecord, DecryptionResult>
 typealias TransformationProcessingResult = Pair<SourceRecord, TransformationResult>
+typealias FilterProcessingResult = Pair<SourceRecord, FilterResult>
 
 typealias SourceRecordProcessingOutput = Either<SourceRecord, SourceRecordProcessingResult>
 typealias JsonProcessingOutput = Either<SourceRecord, JsonProcessingResult>
@@ -64,6 +65,6 @@ typealias ExtractionProcessingOutput = Either<SourceRecord, ExtractionProcessing
 typealias DatakeyProcessingOutput = Either<SourceRecord, DatakeyProcessingResult>
 typealias DecryptionProcessingOutput = Either<SourceRecord, DecryptionProcessingResult>
 typealias TransformationProcessingOutput = Either<SourceRecord, TransformationProcessingResult>
-typealias DeleteProcessingOutput = Either<SourceRecord, DeleteProcessingResult>
+typealias FilterProcessingOutput = Either<SourceRecord, FilterProcessingResult>
 
 

--- a/src/main/kotlin/ucfs/claimant/consumer/orchestrate/impl/OrchestratorImpl.kt
+++ b/src/main/kotlin/ucfs/claimant/consumer/orchestrate/impl/OrchestratorImpl.kt
@@ -56,7 +56,7 @@ class OrchestratorImpl(private val consumerProvider: () -> KafkaConsumer<ByteArr
     }
 
 
-    private suspend fun KafkaConsumer<ByteArray, ByteArray>.processPartitionRecords(topicPartition: TopicPartition, records: List<ConsumerRecord<ByteArray, ByteArray>>) =
+    private suspend fun KafkaConsumer<ByteArray, ByteArray>.processPartitionRecords(topicPartition: TopicPartition, records: List<SourceRecord>) =
             sendToTargets(topicPartition.topic(), records).fold(
                 ifRight = {
                     lastPosition(records).let { lastPosition ->
@@ -73,7 +73,7 @@ class OrchestratorImpl(private val consumerProvider: () -> KafkaConsumer<ByteArr
                     rollback(topicPartition)
                 })
 
-   private suspend fun sendToTargets(topic: String, records: List<ConsumerRecord<ByteArray, ByteArray>>) =
+   private suspend fun sendToTargets(topic: String, records: List<SourceRecord>) =
             Either.catch {
                 val (successfullySourced, failedPreprocessing) = splitPreprocessed(records)
                 val (additionsAndModifications, deletes) = splitActions(successfullySourced)

--- a/src/main/kotlin/ucfs/claimant/consumer/processor/CompoundProcessor.kt
+++ b/src/main/kotlin/ucfs/claimant/consumer/processor/CompoundProcessor.kt
@@ -2,7 +2,6 @@ package ucfs.claimant.consumer.processor
 
 import ucfs.claimant.consumer.domain.FilterProcessingOutput
 import ucfs.claimant.consumer.domain.JsonProcessingResult
-import ucfs.claimant.consumer.domain.TransformationProcessingOutput
 
 interface CompoundProcessor {
     fun process(input: JsonProcessingResult): FilterProcessingOutput

--- a/src/main/kotlin/ucfs/claimant/consumer/processor/CompoundProcessor.kt
+++ b/src/main/kotlin/ucfs/claimant/consumer/processor/CompoundProcessor.kt
@@ -1,8 +1,9 @@
 package ucfs.claimant.consumer.processor
 
+import ucfs.claimant.consumer.domain.FilterProcessingOutput
 import ucfs.claimant.consumer.domain.JsonProcessingResult
 import ucfs.claimant.consumer.domain.TransformationProcessingOutput
 
 interface CompoundProcessor {
-    fun process(input: JsonProcessingResult): TransformationProcessingOutput
+    fun process(input: JsonProcessingResult): FilterProcessingOutput
 }

--- a/src/main/kotlin/ucfs/claimant/consumer/processor/DelegateProcessors.kt
+++ b/src/main/kotlin/ucfs/claimant/consumer/processor/DelegateProcessors.kt
@@ -13,3 +13,4 @@ interface ExtractionProcessor : DelegateProcessor<JsonProcessingResult, Extracti
 interface DatakeyProcessor : DelegateProcessor<ExtractionProcessingResult, DatakeyProcessingOutput>
 interface DecryptionProcessor : DelegateProcessor<DatakeyProcessingResult, DecryptionProcessingOutput>
 interface TransformationProcessor : DelegateProcessor<DecryptionProcessingResult, TransformationProcessingOutput>
+interface FilterProcessor : DelegateProcessor<TransformationProcessingResult, FilterProcessingOutput>

--- a/src/main/kotlin/ucfs/claimant/consumer/processor/impl/CompoundProcessorImpl.kt
+++ b/src/main/kotlin/ucfs/claimant/consumer/processor/impl/CompoundProcessorImpl.kt
@@ -2,18 +2,20 @@ package ucfs.claimant.consumer.processor.impl
 
 import arrow.core.flatMap
 import org.springframework.stereotype.Component
+import ucfs.claimant.consumer.domain.FilterProcessingOutput
 import ucfs.claimant.consumer.domain.JsonProcessingResult
-import ucfs.claimant.consumer.domain.TransformationProcessingOutput
 import ucfs.claimant.consumer.processor.*
 
 @Component
 class CompoundProcessorImpl(private val extractionProcessor: ExtractionProcessor,
                             private val datakeyProcessor: DatakeyProcessor,
                             private val decryptionProcessor: DecryptionProcessor,
-                            private val transformationProcessor: TransformationProcessor) : CompoundProcessor {
-    override fun process(input: JsonProcessingResult): TransformationProcessingOutput =
+                            private val transformationProcessor: TransformationProcessor,
+                            private val filterProcessor: FilterProcessor) : CompoundProcessor {
+    override fun process(input: JsonProcessingResult): FilterProcessingOutput =
         extractionProcessor.process(input)
                     .flatMap(datakeyProcessor::process)
                     .flatMap(decryptionProcessor::process)
                     .flatMap(transformationProcessor::process)
+                    .flatMap(filterProcessor::process)
 }

--- a/src/main/kotlin/ucfs/claimant/consumer/processor/impl/FilterProcessorImpl.kt
+++ b/src/main/kotlin/ucfs/claimant/consumer/processor/impl/FilterProcessorImpl.kt
@@ -13,13 +13,12 @@ import ucfs.claimant.consumer.utility.GsonExtensions.nullableString
 
 @Component
 class FilterProcessorImpl(private val claimantTopic: String): FilterProcessor {
-    override fun process(record: TransformationProcessingResult): FilterProcessingOutput {
-        return filter(record.first.topic(), record.second.transformedDbObject).map {
+    override fun process(record: TransformationProcessingResult): FilterProcessingOutput =
+        filter(record.first.topic(), record.second.transformedDbObject).map {
             Pair(record.first, FilterResult(record.second, it))
         }.mapLeft {
             FunctionalUtility.processingFailure(record.first, it,"Failed to perform filtering on transformed object from '${record.first.topic()}'.")
         }
-    }
 
     private fun filter(topic: String, transformed: String): Either<Any, Boolean> =
         if (topic == claimantTopic) {

--- a/src/main/kotlin/ucfs/claimant/consumer/processor/impl/FilterProcessorImpl.kt
+++ b/src/main/kotlin/ucfs/claimant/consumer/processor/impl/FilterProcessorImpl.kt
@@ -1,0 +1,33 @@
+package ucfs.claimant.consumer.processor.impl
+
+import arrow.core.Either
+import arrow.core.right
+import org.springframework.stereotype.Component
+import ucfs.claimant.consumer.domain.FilterProcessingOutput
+import ucfs.claimant.consumer.domain.FilterResult
+import ucfs.claimant.consumer.domain.TransformationProcessingResult
+import ucfs.claimant.consumer.processor.FilterProcessor
+import ucfs.claimant.consumer.utility.FunctionalUtility
+import ucfs.claimant.consumer.utility.GsonExtensions.jsonObject
+import ucfs.claimant.consumer.utility.GsonExtensions.nullableString
+
+@Component
+class FilterProcessorImpl(private val claimantTopic: String): FilterProcessor {
+    override fun process(record: TransformationProcessingResult): FilterProcessingOutput {
+        return filter(record.first.topic(), record.second.transformedDbObject).map {
+            Pair(record.first, FilterResult(record.second, it))
+        }.mapLeft {
+            FunctionalUtility.processingFailure(record.first, it,"Failed to perform filtering on transformed object from '${record.first.topic()}'.")
+        }
+    }
+
+    private fun filter(topic: String, transformed: String): Either<Any, Boolean> =
+        if (topic == claimantTopic) {
+            transformed.jsonObject().map {
+                it.nullableString("nino")?.run(String::isNotBlank) ?: false
+            }
+        }
+        else {
+            true.right()
+        }
+}

--- a/src/main/kotlin/ucfs/claimant/consumer/target/SuccessTarget.kt
+++ b/src/main/kotlin/ucfs/claimant/consumer/target/SuccessTarget.kt
@@ -1,9 +1,9 @@
 package ucfs.claimant.consumer.target
 
+import ucfs.claimant.consumer.domain.FilterProcessingResult
 import ucfs.claimant.consumer.domain.JsonProcessingResult
-import ucfs.claimant.consumer.domain.TransformationProcessingResult
 
 interface SuccessTarget {
-    suspend fun upsert(topic: String, records: List<TransformationProcessingResult>)
+    suspend fun upsert(topic: String, records: List<FilterProcessingResult>)
     suspend fun delete(topic: String, records: List<JsonProcessingResult>)
 }

--- a/src/main/kotlin/ucfs/claimant/consumer/utility/GsonExtensions.kt
+++ b/src/main/kotlin/ucfs/claimant/consumer/utility/GsonExtensions.kt
@@ -19,6 +19,7 @@ object GsonExtensions {
 
     fun JsonObject.nullableInteger(vararg path: String): Number? = integer(*path).orNull()
     fun JsonObject.nullableObject(vararg path: String): JsonObject? = getObject(*path).orNull()
+    fun JsonObject.nullableString(vararg path: String): String? = string(*path).orNull()
 
     fun JsonObject.string(vararg path: String): Either<Pair<JsonObject, String>, String> =
         primitive(JsonPrimitive::isString, JsonPrimitive::getAsString, *path)

--- a/src/test/kotlin/ucfs/claimant/consumer/orchestrate/impl/OrchestratorCommitTest.kt
+++ b/src/test/kotlin/ucfs/claimant/consumer/orchestrate/impl/OrchestratorCommitTest.kt
@@ -73,9 +73,9 @@ class OrchestratorCommitTest : StringSpec() {
 
     }
 
-    private fun transformationResult() = TransformationResult(
+    private fun transformationResult() = FilterResult(TransformationResult(
         JsonProcessingExtract(JsonObject(), "id", DatabaseAction.MONGO_UPDATE, Pair("2020-01-01", "_lastModifiedDateTime")),
-        "TRANSFORMED_DB_OBJECT")
+        "TRANSFORMED_DB_OBJECT"), true)
 
     private fun orchestrator(
         provider: () -> KafkaConsumer<ByteArray, ByteArray>,

--- a/src/test/kotlin/ucfs/claimant/consumer/processor/impl/FilterProcessorImplTest.kt
+++ b/src/test/kotlin/ucfs/claimant/consumer/processor/impl/FilterProcessorImplTest.kt
@@ -15,7 +15,7 @@ import ucfs.claimant.consumer.domain.*
 class FilterProcessorImplTest: StringSpec() {
 
     init {
-        "Return right true if not contract and well formed json" {
+        "Return right true if not claimant and well formed json" {
             forAll(*nonClaimant) { topic ->
                 allowedThrough("{}", topic).shouldBeRight {
                     it.second.passThrough.shouldBeTrue()
@@ -23,7 +23,7 @@ class FilterProcessorImplTest: StringSpec() {
             }
         }
 
-        "Return right true if not contract and malformed json" {
+        "Return right true if not claimant and malformed json" {
             forAll(*nonClaimant) { topic ->
                 allowedThrough("{", topic).shouldBeRight {
                     it.second.passThrough.shouldBeTrue()

--- a/src/test/kotlin/ucfs/claimant/consumer/processor/impl/FilterProcessorImplTest.kt
+++ b/src/test/kotlin/ucfs/claimant/consumer/processor/impl/FilterProcessorImplTest.kt
@@ -1,0 +1,82 @@
+package ucfs.claimant.consumer.processor.impl
+
+import com.google.gson.JsonObject
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import io.kotest.assertions.arrow.either.shouldBeLeft
+import io.kotest.assertions.arrow.either.shouldBeRight
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.data.blocking.forAll
+import io.kotest.data.row
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import ucfs.claimant.consumer.domain.*
+
+class FilterProcessorImplTest: StringSpec() {
+
+    init {
+        "Return right true if not contract and well formed json" {
+            forAll(*nonClaimant) { topic ->
+                allowedThrough("{}", topic).shouldBeRight {
+                    it.second.passThrough.shouldBeTrue()
+                }
+            }
+        }
+
+        "Return right true if not contract and malformed json" {
+            forAll(*nonClaimant) { topic ->
+                allowedThrough("{", topic).shouldBeRight {
+                    it.second.passThrough.shouldBeTrue()
+                }
+            }
+        }
+
+        "Return right true if claimant and nino not blank" {
+            allowedThrough("""{ "nino": "123" }""").shouldBeRight {
+                it.second.passThrough.shouldBeTrue()
+            }
+        }
+
+        "Return right false if claimant and nino empty" {
+            allowedThrough("""{ "nino": "" }""").shouldBeRight {
+                it.second.passThrough.shouldBeFalse()
+            }
+        }
+
+        "Return left if claimant and malformed" {
+            allowedThrough("""{ "nino": }""").shouldBeLeft()
+        }
+
+        "Return right false if claimant and nino blank" {
+            allowedThrough("""{ "nino": "   " }""").shouldBeRight {
+                it.second.passThrough.shouldBeFalse()
+            }
+        }
+
+        "Return right false if claimant and nino absent" {
+            allowedThrough("{}").shouldBeRight {
+                it.second.passThrough.shouldBeFalse()
+            }
+        }
+    }
+
+    companion object {
+        private fun allowedThrough(json: String, topic: String = claimantTopic) =
+            FilterProcessorImpl(claimantTopic).process(processingResult(json, topic))
+
+        private fun processingResult(json: String, topic: String): TransformationProcessingResult {
+            val record = mock<SourceRecord> {
+                on { topic() } doReturn topic
+                on { key() } doReturn ByteArray(0)
+            }
+            return TransformationProcessingResult(record, transformationResult(json))
+        }
+
+        private fun transformationResult(json: String): TransformationResult = TransformationResult(extract, json)
+        private val extract = JsonProcessingExtract(JsonObject(), "", DatabaseAction.MONGO_UPDATE, Pair("", ""))
+        private const val claimantTopic = "db.core.claimant"
+        private const val contractTopic = "db.core.contract"
+        private const val statementTopic = "db.core.statement"
+        private val nonClaimant = listOf(contractTopic, statementTopic).map(::row).toTypedArray()
+    }
+}

--- a/src/test/kotlin/ucfs/claimant/consumer/processor/impl/SourceData.kt
+++ b/src/test/kotlin/ucfs/claimant/consumer/processor/impl/SourceData.kt
@@ -6,12 +6,12 @@ import ucfs.claimant.consumer.domain.JsonProcessingExtract
 
 object SourceData {
     const val claimantTopic = "db.core.claimant"
-    const val contractTopic = "db.core.contract"
-    const val statementTopic = "db.core.statement"
+    private const val contractTopic = "db.core.contract"
+    private const val statementTopic = "db.core.statement"
 
     const val claimantIdSourceField = "citizenId"
-    const val contractIdSourceField = "contractId"
-    const val statementIdSourceField = "statementId"
+    private const val contractIdSourceField = "contractId"
+    private const val statementIdSourceField = "statementId"
 
     val idSourceFields =
         mapOf(claimantTopic to claimantIdSourceField,

--- a/src/test/kotlin/ucfs/claimant/consumer/transformer/impl/ClaimantTransformerTest.kt
+++ b/src/test/kotlin/ucfs/claimant/consumer/transformer/impl/ClaimantTransformerTest.kt
@@ -21,11 +21,27 @@ class ClaimantTransformerTest: StringSpec() {
             }
         }
 
-        "Returns left if nino missing" {
-            transformer().transform(jsonObject(invalidJsonMissingNino)) shouldBeLeft {
-                it.shouldBeTypeOf<Pair<JsonObject, String>>()
-                it.first.json() shouldMatchJson invalidJsonMissingNino
-                it.second shouldBe "nino"
+        "Returns right if nino missing" {
+            transformer().transform(jsonObject(invalidJsonMissingNino)) shouldBeRight {
+                it shouldMatchJson noNinoOutput
+            }
+        }
+
+        "Returns right if nino empty" {
+            transformer().transform(jsonObject(invalidJsonEmptyNino)) shouldBeRight {
+                it shouldMatchJson noNinoOutput
+            }
+        }
+
+        "Returns right if nino blank" {
+            transformer().transform(jsonObject(invalidJsonBlankNino)) shouldBeRight {
+                it shouldMatchJson noNinoOutput
+            }
+        }
+
+        "Returns right if nino null" {
+            transformer().transform(jsonObject(invalidJsonNullNino)) shouldBeRight {
+                it shouldMatchJson noNinoOutput
             }
         }
 
@@ -69,6 +85,30 @@ class ClaimantTransformerTest: StringSpec() {
                 }
             }"""
 
+        private const val invalidJsonEmptyNino =
+            """{
+                "_id": {
+                    "citizenId": "2bee0d32-4e18-477c-b5b1-b46d7952a927"
+                },
+                "nino": ""
+            }"""
+
+        private const val invalidJsonBlankNino =
+            """{
+                "_id": {
+                    "citizenId": "2bee0d32-4e18-477c-b5b1-b46d7952a927"
+                },
+                "nino": "    "
+            }"""
+
+        private const val invalidJsonNullNino =
+            """{
+                "_id": {
+                    "citizenId": "2bee0d32-4e18-477c-b5b1-b46d7952a927"
+                },
+                "nino": null
+            }"""
+
         private const val invalidJsonMissingEverything = "{}"
 
         private const val expectedOutput =
@@ -77,6 +117,14 @@ class ClaimantTransformerTest: StringSpec() {
                     "citizenId": "2bee0d32-4e18-477c-b5b1-b46d7952a927"
                 },
                 "nino": "xFJrf8lbU4G-LB3gx6uF0z531bs0DIVYQ5o5514Y5OrrlxEriQ_W-jEum6bgveIL9gFwwRswDXz8lgqmTQCgFg=="
+            }"""
+
+        private const val noNinoOutput =
+            """{
+                "_id": {
+                    "citizenId": "2bee0d32-4e18-477c-b5b1-b46d7952a927"
+                },
+                "nino": ""
             }"""
 
         private fun transformer() = ClaimantTransformer(saltProvider())

--- a/src/test/kotlin/ucfs/claimant/consumer/utility/GsonExtensionsTest.kt
+++ b/src/test/kotlin/ucfs/claimant/consumer/utility/GsonExtensionsTest.kt
@@ -15,11 +15,42 @@ import ucfs.claimant.consumer.utility.GsonExtensions.json
 import ucfs.claimant.consumer.utility.GsonExtensions.jsonObject
 import ucfs.claimant.consumer.utility.GsonExtensions.list
 import ucfs.claimant.consumer.utility.GsonExtensions.nullableInteger
+import ucfs.claimant.consumer.utility.GsonExtensions.nullableString
 import ucfs.claimant.consumer.utility.GsonExtensions.string
 
 class GsonExtensionsTest : StringSpec() {
 
     init {
+
+        "Nullable string return value if present" {
+            val obj = Gson().fromJson("""{ "key": "123" }""", JsonObject::class.java)
+            val result = obj.nullableString("key")
+            result shouldBe "123"
+        }
+
+        "Nullable string return value if empty" {
+            val obj = Gson().fromJson("""{ "key": "" }""", JsonObject::class.java)
+            val result = obj.nullableString("key")
+            result shouldBe ""
+        }
+
+        "Nullable string return value if blank" {
+            val obj = Gson().fromJson("""{ "key": "   " }""", JsonObject::class.java)
+            val result = obj.nullableString("key")
+            result shouldBe "   "
+        }
+
+        "Nullable string returns null if value null" {
+            val obj = Gson().fromJson("""{ "key": null }""", JsonObject::class.java)
+            val result = obj.nullableString("key")
+            result shouldBe null
+        }
+
+        "Nullable string returns null if key not present" {
+            val obj = Gson().fromJson("""{}""", JsonObject::class.java)
+            val result = obj.nullableInteger("key")
+            result shouldBe null
+        }
 
         "Nullable integer return value if present" {
             val obj = Gson().fromJson("""{ "key": 123 }""", JsonObject::class.java)


### PR DESCRIPTION
The filter processor filters out records that we don't want to put
in the database but are otherwise valid and so should not go on
the DLQ.

At present it only serves to filter out claimant records with no
nino.
