### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
         id: certificates
         run: make certificates
       - name: Publish to DockerHub
-        uses: elgohr/Publish-Docker-Github-Action@191af57e15535d28b83589e3b5f0c31e76aa8733 #v3.0.4 hardcoded for security DW-5986, review regularly
+        uses: elgohr/Publish-Docker-Github-Action@v5 #v3.0.4 hardcoded for security DW-5986, review regularly
         with:
           name: ${{ env.IMAGE_NAME }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore